### PR TITLE
Changes to make ASTInterpreter2 compile under Julia 1.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.6
 DebuggerFramework 0.1.1
+Nullables
+Markdown

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -1,3 +1,5 @@
+using Markdown
+
 function perform_return!(state)
     returning_frame = state.stack[1]
     returning_expr = pc_expr(returning_frame)
@@ -157,7 +159,7 @@ end
 
 function DebuggerFramework.execute_command(state, frane::JuliaStackFrame, ::Val{:?}, cmd)
     display(
-            Base.@md_str """
+            @md_str """
     Basic Commands:\\
     - `n` steps to the next line\\
     - `s` steps into the next call\\

--- a/src/linearize.jl
+++ b/src/linearize.jl
@@ -1,6 +1,7 @@
+
 # Linearizer. Future versions of julia will emit fully-linear IR, so this way upgrading should be easier.
 # This is taken from inference.jl on julia master
-function newvar!(code::CodeInfo, typ)
+function newvar!(code::Core.CodeInfo, typ)
     if isa(code.ssavaluetypes, Int)
         id = code.ssavaluetypes::Int
         code.ssavaluetypes = id + 1
@@ -8,7 +9,7 @@ function newvar!(code::CodeInfo, typ)
         id = length(code.ssavaluetypes)
         push!(code.ssavaluetypes, typ)
     end
-    return SSAValue(id)
+    return Core.SSAValue(id)
 end
 
 is_meta_expr_head(head::Symbol) =
@@ -21,7 +22,7 @@ function is_ccall_static(e::Expr)
         length(e.args) == 3 || return false
         for i in 2:3
             a = e.args[i]
-            (isa(a, Expr) || isa(a, Slot) || isa(a, SSAValue)) && return false
+            (isa(a, Expr) || isa(a, Slot) || isa(a, Core.SSAValue)) && return false
         end
         return true
     elseif e.head === :static_parameter
@@ -30,7 +31,7 @@ function is_ccall_static(e::Expr)
     return false
 end
 
-function linearize_arg!(args, i, stmts, code::CodeInfo)
+function linearize_arg!(args, i, stmts, code::Core.CodeInfo)
     a = args[i]
     if isa(a, Symbol)
         a = a::Symbol
@@ -90,7 +91,7 @@ function relabel!(body::Vector{Any})
     end
 end
 
-function linearize!(code::CodeInfo)
+function linearize!(code::Core.CodeInfo)
     body = code.code
     len = length(body)
     next_i = 1


### PR DESCRIPTION
Made compile under Julia 1.0 by accounting for variable renames.

While it compiles, I haven't tested it since I haven't been able to find the documentation.